### PR TITLE
Forward compatibility with react/event-loop 1.0 and 0.5 while still supporting 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Integrate Recoil with ReactPHP.",
     "require": {
         "php": "^7",
-        "react/event-loop": "^0.4",
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4",
         "react/promise": "^2",
         "recoil/api": "^1",
         "recoil/kernel": "^1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e323dba67791ce7360fbc8f4c924057",
+    "content-hash": "e538107f99cbf060ea1c14c2df65bbda",
     "packages": [
         {
             "name": "icecave/repr",
@@ -59,28 +59,27 @@
         },
         {
             "name": "react/event-loop",
-            "version": "v0.4.3",
+            "version": "v0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "8bde03488ee897dc6bb3d91e4e17c353f9c5252f"
+                "reference": "f3ab8edeb6416466a73b1217b3af475ce9e3b087"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/8bde03488ee897dc6bb3d91e4e17c353f9c5252f",
-                "reference": "8bde03488ee897dc6bb3d91e4e17c353f9c5252f",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/f3ab8edeb6416466a73b1217b3af475ce9e3b087",
+                "reference": "f3ab8edeb6416466a73b1217b3af475ce9e3b087",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "~4.8.35 || ^5.7 || ^6.4"
             },
             "suggest": {
-                "ext-event": "~1.0",
-                "ext-libev": "*",
-                "ext-libevent": ">=0.1.0"
+                "ext-event": "~1.0 for ExtEventLoop",
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
             },
             "type": "library",
             "autoload": {
@@ -92,12 +91,12 @@
             "license": [
                 "MIT"
             ],
-            "description": "Event loop abstraction layer that libraries can use for evented I/O.",
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
             "keywords": [
                 "asynchronous",
                 "event-loop"
             ],
-            "time": "2017-04-27T10:56:23+00:00"
+            "time": "2018-04-05T11:53:43+00:00"
         },
         {
             "name": "react/promise",

--- a/src/ReactApi.php
+++ b/src/ReactApi.php
@@ -61,9 +61,10 @@ final class ReactApi implements Api
                 }
             );
 
+            $eventLoop = $this->eventLoop;
             $strand->setTerminator(
-                static function () use ($timer) {
-                    $timer->cancel();
+                static function () use ($eventLoop, $timer) {
+                    $eventLoop->cancelTimer($timer);
                 }
             );
         } else {

--- a/src/StrandTimeout.php
+++ b/src/StrandTimeout.php
@@ -69,7 +69,7 @@ final class StrandTimeout implements Awaitable, Listener
         assert($this->substrand === $strand, 'unknown strand');
 
         $this->substrand = null;
-        $this->timer->cancel();
+        $this->eventLoop->cancelTimer($this->timer);
         $this->listener->send($value);
     }
 
@@ -84,7 +84,7 @@ final class StrandTimeout implements Awaitable, Listener
         assert($this->substrand === $strand, 'unknown strand');
 
         $this->substrand = null;
-        $this->timer->cancel();
+        $this->eventLoop->cancelTimer($this->timer);
         $this->listener->throw($exception);
     }
 
@@ -94,7 +94,7 @@ final class StrandTimeout implements Awaitable, Listener
     public function cancel()
     {
         if ($this->substrand) {
-            $this->timer->cancel();
+            $this->eventLoop->cancelTimer($this->timer);
             $this->substrand->clearPrimaryListener();
             $this->substrand->terminate();
         }

--- a/test/suite/unit/ReactApi.spec.php
+++ b/test/suite/unit/ReactApi.spec.php
@@ -7,10 +7,14 @@ namespace Recoil\React;
 use Eloquent\Phony\Phony;
 use Hamcrest\Core\IsInstanceOf;
 use React\EventLoop\LoopInterface;
-use React\EventLoop\Timer\TimerInterface;
+use React\EventLoop\TimerInterface;
 use Recoil\Kernel\SystemKernel;
 use Recoil\Kernel\SystemStrand;
 use Recoil\Strand;
+
+if (!interface_exists('React\EventLoop\TimerInterface') && interface_exists('React\EventLoop\Timer\TimerInterface')) {
+    class_alias('React\EventLoop\Timer\TimerInterface', 'React\EventLoop\TimerInterface');
+}
 
 describe(ReactApi::class, function () {
     beforeEach(function () {
@@ -72,9 +76,9 @@ describe(ReactApi::class, function () {
             $cancel = $this->strand->setTerminator->called()->firstCall()->argument();
             expect($cancel)->to->satisfy('is_callable');
 
-            $this->timer->cancel->never()->called();
+            $this->eventLoop->cancelTimer->never()->called();
             $cancel();
-            $this->timer->cancel->called();
+            $this->eventLoop->cancelTimer->called();
         });
 
         it('uses future tick instead of a timer when passed zero seconds', function () {

--- a/test/suite/unit/StrandTimeout.spec.php
+++ b/test/suite/unit/StrandTimeout.spec.php
@@ -6,12 +6,16 @@ namespace Recoil\React;
 
 use Eloquent\Phony\Phony;
 use React\EventLoop\LoopInterface;
-use React\EventLoop\Timer\TimerInterface;
+use React\EventLoop\TimerInterface;
 use Recoil\Exception\TimeoutException;
 use Recoil\Kernel\Api;
 use Recoil\Kernel\Strand;
 use Recoil\Kernel\SystemStrand;
 use Throwable;
+
+if (!interface_exists('React\EventLoop\TimerInterface') && interface_exists('React\EventLoop\Timer\TimerInterface')) {
+    class_alias('React\EventLoop\Timer\TimerInterface', 'React\EventLoop\TimerInterface');
+}
 
 describe(StrandTimeout::class, function () {
     beforeEach(function () {
@@ -53,7 +57,7 @@ describe(StrandTimeout::class, function () {
 
             $this->subject->send('<ok>', $this->substrand->get());
 
-            $this->timer->cancel->called();
+            $this->loop->cancelTimer->called();
             $this->strand->send->calledWith('<ok>');
         });
 
@@ -61,7 +65,7 @@ describe(StrandTimeout::class, function () {
             $exception = Phony::mock(Throwable::class);
             $this->subject->throw($exception->get(), $this->substrand->get());
 
-            $this->timer->cancel->called();
+            $this->loop->cancelTimer->called();
             $this->strand->throw->calledWith($exception);
         });
 


### PR DESCRIPTION
We've just released `react/event-loop` [0.5](https://github.com/reactphp/event-loop/releases/tag/v0.5.0) which will be our last BC breaking release before 1.0. And aside from a few minor changes, `recoil/react` is fully compatible :tada: .