### PR TITLE
Handle empty error_get_last() after fwrite() error.

### DIFF
--- a/src/ReactApi.php
+++ b/src/ReactApi.php
@@ -201,6 +201,7 @@ final class ReactApi implements Api
                 &$buffer,
                 &$length
             ) {
+                \error_clear_last();
                 $bytes = @\fwrite($stream, $buffer, $length);
 
                 // zero and false both indicate an error
@@ -209,15 +210,26 @@ final class ReactApi implements Api
                     // @codeCoverageIgnoreStart
                     $done();
                     $error = \error_get_last();
-                    $strand->throw(
-                        new ErrorException(
-                            $error['message'],
-                            $error['type'],
-                            1, // severity
-                            $error['file'],
-                            $error['line']
-                        )
-                    );
+
+                    if ($error !== null) {
+                        $strand->throw(
+                            new ErrorException(
+                                $error['message'],
+                                $error['type'],
+                                1, // severity
+                                $error['file'],
+                                $error['line']
+                            )
+                        );
+                    } else {
+                        $strand->throw(
+                            new ErrorException(
+                                'Stream write error',
+                                0,
+                                1 // severity
+                            )
+                        );
+                    }
                     // @codeCoverageIgnoreEnd
                 } elseif ($bytes === $length) {
                     $done();


### PR DESCRIPTION
Follow up for 5c47be8e1a320c7a42d721895ef063b415d85084: It seems that `error_get_last()` is not always set when `fwrite()` returns zero (in my case (#6) this should be an equivalent of EPIPE, but no). This results either in a crash (null access) or a bogus exception with old data.